### PR TITLE
fix: smtp port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@ DB_USER=developer
 DB_PASS=developer
 
 SMTP_HOST=mail
-SMTP_PORT=1025
+SMTP_PORT=25


### PR DESCRIPTION
The SMTP port for maildev was incorrectly modified in (#10) to the port that is exposed on the host, rather than the one accessible within the docker network